### PR TITLE
Support case when __module__ is set to None

### DIFF
--- a/pysv/frame.py
+++ b/pysv/frame.py
@@ -41,7 +41,7 @@ def _get_import_name(val, check_type=True):
         return val.__name__
     else:
         # we support class type import as well
-        if not hasattr(val, "__module__"):
+        if not getattr(val, "__module__", None):
             return None
         module_name = val.__module__.split(".")[0]
         full_name = None


### PR DESCRIPTION
Sometimes (e.g. when you exec code inside a string), an object will have
a __module__ attribute, but it will be set to None