### PR TITLE
Add support for _source_code_ attribute for runtime generated class definitions

### DIFF
--- a/pysv/pyast.py
+++ b/pysv/pyast.py
@@ -46,7 +46,15 @@ def has_return(func: typing.Callable):
 def get_class_src(cls: type):
     # we need to remove all the @dpi decorators in the ast
     # so that they can actually be called
-    code = inspect.getsource(cls)
+    if hasattr(cls, "_source_code_"):
+        # If we define a class inside exec (e.g. when doing AST rewrites on the
+        # Python source) we can't use inspect.getsource (since the code comes
+        # froms a string rather than a file).  So, we provide a special
+        # attribute that downstream tools can use to store the generated source
+        # code
+        code = cls._source_code_
+    else:
+        code = inspect.getsource(cls)
     class_tree = ast.parse(textwrap.dedent(code))
     # need to clear out any DPI function decorator
     class_ast = class_tree.body[0]


### PR DESCRIPTION
For fault, I am trying to do a runtime generated class definition (need to do rewrites to add logic that converts the function interface from magma types to system verilog types, so we need to do things like flatten the arguments for tuples).  inspect.getsource doesn't work when we use exec to define a class (since it tries to look for the file it was defined in.  This adds a special magic attribute that a downstream tool can set on a class that provides the source code so we can avoid using inspect.