### PR TITLE
Add support for returning tuples implemented in a class method

### DIFF
--- a/pysv/codegen.py
+++ b/pysv/codegen.py
@@ -673,7 +673,10 @@ def generate_cxx_class_method(func, is_class, class_name, pretty_print=True):
         args = arg_names
     if func.is_init:
         args = args[1:]
-    args = "{0}({1});".format(func_name, ", ".join(args))
+    if len(func.output_names) > 0 :
+        args = "{0}({1}, {2});".format(func_name, ", ".join(args), ", ".join(func.output_names))
+    else:
+        args = "{0}({1});".format(func_name, ", ".join(args))
     tokens = []
     if func.is_init:
         tokens.append(pointer_name)

--- a/pysv/codegen.py
+++ b/pysv/codegen.py
@@ -764,7 +764,9 @@ def generate_sv_class_method(func, pretty_print: bool = True, ref_ctor: bool = F
                 result += indentation + "obj__.{0} = ptr__;\n".format(chandle_name)
                 result += indentation + "return obj__;\n"
         else:
-            if func.return_type == DataType.Void:
+            if len(func.output_names) > 0 :
+                result += indentation + "{0}({1}, {2});\n".format(func.func_name, args, ", ".join(func.output_names))
+            elif func.return_type == DataType.Void:
                 result += indentation + "{0}({1});\n".format(func.func_name, args)
             else:
                 result += indentation + "return {0}({1});\n".format(func.func_name, args)

--- a/tests/gold/test_generate_cxx_binding.cc
+++ b/tests/gold/test_generate_cxx_binding.cc
@@ -3,6 +3,11 @@
 #include <iostream>
 extern "C" {
 void* SomeClass_pysv_init();
+void SomeClass_add_sub(void* self,
+                       uint32_t a,
+                       uint32_t b,
+                       uint32_t *res_add,
+                       uint32_t *res_sub);
 void SomeClass_destroy(void* self);
 int32_t SomeClass_plus(void* self,
                        int32_t num);
@@ -24,6 +29,10 @@ public:
 class SomeClass : public PySVObject {
 public:
   SomeClass();
+  void add_sub(uint32_t a,
+               uint32_t b,
+               uint32_t *res_add,
+               uint32_t *res_sub);
   ~SomeClass() override;
   int32_t plus(int32_t num);
   void print_a();

--- a/tests/gold/test_generate_cxx_code_class.cc
+++ b/tests/gold/test_generate_cxx_code_class.cc
@@ -1,0 +1,235 @@
+#include "pybind11/include/pybind11/embed.h"
+#include "pybind11/include/pybind11/eval.h"
+#include <iostream>
+#include <unordered_map>
+#include <memory>
+
+// used for ModelSim/Questa to resolve some runtime native library loading issues
+// not needed for Xcelium and vcs, but include just in case
+#ifdef __linux__
+#include <dlfcn.h>
+#endif
+namespace py = pybind11;
+std::unique_ptr<std::unordered_map<std::string, py::object>> global_imports = nullptr;
+std::unique_ptr<py::scoped_interpreter> guard = nullptr;
+std::unique_ptr<std::unordered_map<void*, py::object>> py_obj_map;
+std::unique_ptr<py::dict> class_defs;
+std::string string_result_value;
+
+void check_interpreter() {
+    if (!guard) guard = std::unique_ptr<py::scoped_interpreter>(new py::scoped_interpreter());
+}
+template<class ...Args>
+py::object call_class_func(void *py_ptr, const std::string &func_name, Args &&...args) {
+    if (!py_obj_map) return py::none();
+    if (py_obj_map->find(py_ptr) == py_obj_map->end()) {
+        std::cerr << "ERROR: unable to call function " << func_name
+                  << " from ptr " << py_ptr << std::endl;
+        return py::none();
+    }
+    auto handle = py_obj_map->at(py_ptr);
+
+    // special case for __destroy__ call
+    if (func_name == "destroy") {
+        // this is a special case
+        // 1. manually decrease the reference we increased during object creation
+        handle.dec_ref();
+        // 2. use pybind's RAII to remove the actual reference
+        py_obj_map->erase(py_ptr);
+        return py::none();
+    }
+
+    auto func = handle.attr(func_name.c_str());
+    auto result = func(args...);
+    return result;
+}
+
+void * create_class_func(py::dict &locals, const std::string &class_name) {
+    if (!py_obj_map) {
+        py_obj_map = std::unique_ptr<std::unordered_map<void*, py::object>>(new std::unordered_map<void*, py::object>());
+    }
+    py::object result = locals["__result"];
+    // manually increase the ref count to avoid being gc'ed; just in case
+    result.inc_ref();
+    auto r_ptr = result.ptr();
+    py_obj_map->emplace(r_ptr, result);
+    // also need to taken care of move the class definition to
+    if (!class_name.empty()) {
+        if (!class_defs) {
+            class_defs = std::unique_ptr<py::dict>(new py::dict());
+        }
+        (*class_defs)[class_name.c_str()] = locals[class_name.c_str()];
+    }
+    return r_ptr;
+}
+void load_class_defs(py::dict &globals) {
+    if (class_defs) {
+        for (auto const &iter: (*class_defs)) {
+            globals[iter.first] = iter.second;
+        }
+    }
+}
+
+extern "C" {
+__attribute__((visibility("default"))) void* SomeClass_pysv_init() {
+  check_interpreter();
+  auto globals = py::dict();
+  load_class_defs(globals);
+  auto locals = py::dict();
+
+  py::exec(R"(
+class SomeClass:
+
+    def __init__(self):
+        self.value = 'hello world\n'
+
+    def print_a(self):
+        print(self.value)
+
+    def print_b(self, num):
+        print(self.value * num)
+
+    def plus(self, num):
+        return num + 1
+
+    def add_sub(self, a, b):
+        return a + b, a - b
+
+__result = SomeClass()
+)", globals, locals);
+  return create_class_func(locals, "SomeClass");
+}
+
+__attribute__((visibility("default"))) void SomeClass_add_sub(void* self,
+                                                              uint32_t a,
+                                                              uint32_t b,
+                                                              uint32_t *res_add,
+                                                              uint32_t *res_sub) {
+  check_interpreter();
+  auto globals = py::dict();
+  load_class_defs(globals);
+  auto locals = py::dict();
+  locals["__self"] = self;
+  locals["__a"] = a;
+  locals["__b"] = b;
+
+  locals["__result"] = call_class_func(self,
+                                       "add_sub",
+                                       locals["__a"],
+                                       locals["__b"]);
+  auto ref_result = locals["__result"].cast<py::list>();
+  if (py::len(ref_result) != 2) {
+    throw std::runtime_error("Invalid return tuple size");
+  }
+  *res_add = ref_result[0].cast<uint32_t>();
+  *res_sub = ref_result[1].cast<uint32_t>();
+}
+
+__attribute__((visibility("default"))) void SomeClass_destroy(void* self) {
+  check_interpreter();
+  auto globals = py::dict();
+  load_class_defs(globals);
+  auto locals = py::dict();
+  locals["__self"] = self;
+
+  locals["__result"] = call_class_func(self,
+                                       "destroy");
+}
+
+__attribute__((visibility("default"))) int32_t SomeClass_plus(void* self,
+                                                              int32_t num) {
+  check_interpreter();
+  auto globals = py::dict();
+  load_class_defs(globals);
+  auto locals = py::dict();
+  locals["__self"] = self;
+  locals["__num"] = num;
+
+  locals["__result"] = call_class_func(self,
+                                       "plus",
+                                       locals["__num"]);
+  return locals["__result"].cast<int32_t>();
+}
+
+__attribute__((visibility("default"))) void SomeClass_print_a(void* self) {
+  check_interpreter();
+  auto globals = py::dict();
+  load_class_defs(globals);
+  auto locals = py::dict();
+  locals["__self"] = self;
+
+  locals["__result"] = call_class_func(self,
+                                       "print_a");
+}
+
+__attribute__((visibility("default"))) void SomeClass_print_b(void* self,
+                                                              int32_t num) {
+  check_interpreter();
+  auto globals = py::dict();
+  load_class_defs(globals);
+  auto locals = py::dict();
+  locals["__self"] = self;
+  locals["__num"] = num;
+
+  locals["__result"] = call_class_func(self,
+                                       "print_b",
+                                       locals["__num"]);
+}
+__attribute__((visibility("default"))) void pysv_finalize() {
+    // clear the cached global imports
+    global_imports.reset();
+    // clear the object map
+    py_obj_map.reset();
+    // clear the class map
+    class_defs.reset();
+    // the last part is tear down the runtime
+    guard.reset();
+}
+}
+#ifndef PYSV_CXX_BINDING
+#define PYSV_CXX_BINDING
+namespace pysv {
+class PySVObject {
+public:
+  PySVObject() = default;
+  PySVObject(void* ptr): pysv_ptr(ptr) {}
+  PySVObject(const PySVObject &obj) : pysv_ptr(obj.pysv_ptr) {}
+  virtual ~PySVObject() = default;
+
+  void *pysv_ptr = nullptr;
+};
+class SomeClass : public PySVObject {
+public:
+  __attribute__((visibility("default")))  SomeClass();
+  __attribute__((visibility("default"))) void add_sub(uint32_t a,
+                                                      uint32_t b,
+                                                      uint32_t *res_add,
+                                                      uint32_t *res_sub);
+  __attribute__((visibility("default")))  ~SomeClass() override;
+  __attribute__((visibility("default"))) int32_t plus(int32_t num);
+  __attribute__((visibility("default"))) void print_a();
+  __attribute__((visibility("default"))) void print_b(int32_t num);
+};
+SomeClass::SomeClass() {
+    pysv_ptr = SomeClass_pysv_init();
+}
+void SomeClass::add_sub(uint32_t a,
+          uint32_t b,
+          uint32_t *res_add,
+          uint32_t *res_sub) {
+    SomeClass_add_sub(pysv_ptr, a, b, res_add, res_sub);
+}
+SomeClass::~SomeClass() {
+    SomeClass_destroy(pysv_ptr);
+}
+int32_t SomeClass::plus(int32_t num) {
+    return SomeClass_plus(pysv_ptr, num);
+}
+void SomeClass::print_a() {
+    SomeClass_print_a(pysv_ptr);
+}
+void SomeClass::print_b(int32_t num) {
+    SomeClass_print_b(pysv_ptr, num);
+}
+}
+#endif // PYSV_CXX_BINDING

--- a/tests/gold/test_generate_sv_binding.sv
+++ b/tests/gold/test_generate_sv_binding.sv
@@ -2,6 +2,11 @@
 `define PYSV_PYSV
 package pysv;
 import "DPI-C" function chandle SomeClass_pysv_init();
+import "DPI-C" function void SomeClass_add_sub(input chandle self,
+                                               input int unsigned a,
+                                               input int unsigned b,
+                                               output int unsigned res_add,
+                                               output int unsigned res_sub);
 import "DPI-C" function void SomeClass_destroy(input chandle self);
 import "DPI-C" function int SomeClass_plus(input chandle self,
                                            input int num);
@@ -15,6 +20,12 @@ endclass
 class SomeClass extends PySVObject;
   function new();
     pysv_ptr = SomeClass_pysv_init();
+  endfunction
+  function void add_sub(input int unsigned a,
+                        input int unsigned b,
+                        output int unsigned res_add,
+                        output int unsigned res_sub);
+    SomeClass_add_sub(pysv_ptr, a, b, res_add, res_sub);
   endfunction
   function void destroy();
     SomeClass_destroy(pysv_ptr);

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,4 +1,4 @@
-from pysv import sv, DataType
+from pysv import sv, DataType, Reference
 from pysv.codegen import (get_python_src, generate_cxx_function, generate_c_header, generate_pybind_code,
                           generate_sv_binding, generate_cxx_binding, generate_dpi_signature)
 # all the module imports in this file should be local to avoid breaking assertions
@@ -75,6 +75,10 @@ class SomeClass:
     @sv()
     def plus(self, num):
         return num + 1
+    
+    @sv(a=DataType.UInt, b=DataType.UInt, return_type=Reference(res_add=DataType.UInt, res_sub=DataType.UInt))
+    def add_sub(self, a, b):
+        return (a+b, a-b)
 
 
 def test_generate_sv_binding(check_file):
@@ -86,6 +90,9 @@ def test_generate_cxx_binding(check_file):
     result = generate_cxx_binding([SomeClass])
     check_file(result, "test_generate_cxx_binding.cc")
 
+def test_generate_cxx_code_class(check_file):
+    result = generate_pybind_code([SomeClass])
+    check_file(result, "test_generate_cxx_code_class.cc")
 
 if __name__ == "__main__":
     test_generate_c_header()


### PR DESCRIPTION
Hello there :)

  I hope this message finds you well. Me and a colleague tried to create a method (within a class) which returned a tuple. However, an error related to the libpysv.cc was being thrown, more specifically, it was a problem with the generated method, it wasn't calling the function correctly, because it wasn't passing the reference arguments (the outputs). To illustrate the problem, here is the output screen shot:

![pysv_error](https://github.com/Kuree/pysv/assets/20645104/0aa97960-9c8b-4c6b-9831-924394f1099c)

The very simple python code is as follows:
```python
from pysv import sv, compile_lib, generate_sv_binding, DataType, Reference
class my_class():
    @sv()
    def __init__(self):
        pass
    @sv(a=DataType.UInt, b=DataType.UInt, return_type=Reference(res_add=DataType.UInt, res_sub=DataType.UInt))
    def sum_sub(self, a, b):
        return (a+b, a-b)

# Compile the a shared_lib into build folder
lib_path = compile_lib([my_class], cwd="build")
# Generate SV binding
generate_sv_binding([my_class], filename="pysv_pkg.sv")
```
Well, it is important to note that this only happens when we implemented a method, the function (outside the class) worked properly.

Therefore, analyzing the source code I realized that the _my_class::sum_sub()_ method body in libpysv.cc was not built properly, since the _generate_cxx_class_method()_ in codegen.py was ignoring the _output_names_ of the function definition.

I added this portion of code there, and the issue seemed to have been fixed. I would like to contribute with this change and if I have made any mistakes in this PR, I apologize and would appreciate any guidance on how to do this correctly.

Thank you in advance for your attention!
