### PR TITLE
Update cmake arg for Python_EXECUTABLE:FILEPATH

### DIFF
--- a/pysv/compile.py
+++ b/pysv/compile.py
@@ -16,7 +16,7 @@ def compile_lib(func_defs, cwd, lib_name="pysv", pretty_print=True, release_buil
     """
     if not os.path.isdir(cwd):
         os.makedirs(cwd, exist_ok=True)
-    # notice that fo follow the "lib" + name convention so the linker can find the library easily
+    # follow the "lib" + name convention so the linker can find the library easily
     if len(lib_name) < 3 or lib_name[:3] != "lib":
         lib_name = "lib" + lib_name
 
@@ -64,7 +64,7 @@ def compile_lib(func_defs, cwd, lib_name="pysv", pretty_print=True, release_buil
     # add header definition
     cmake_args.append("-DDPI_HEADER_DIR=" + vlstd_path)
     # tell cmake where to find python (in case it's not in the system path)
-    cmake_args.append("-DPYTHON_EXECUTABLE=" + sys.executable)
+    cmake_args.append("-DPython_EXECUTABLE:FILEPATH=" + sys.executable)
     subprocess.check_call(["cmake"] + cmake_args + [".."],
                           cwd=build_dir)
     # built it!


### PR DESCRIPTION
This helped me to get this working with the packaged python that comes with Vivado 2024.1

Works with CMake v4.0.2 installed via 
```
john@ASUS:$ LD_LIBRARY_PATH=/tools/Xilinx/Vivado/2024.1/lib/lnx64.o/Ubuntu/22/:/tools/Xilinx/Vivado/2024.1/tps/lnx64/python-3.8.3/lib/ /tools/Xilinx/Vivado/2024.1/tps/lnx64/python-3.8.3/bin/python3.8 -m pip list | grep cmake
cmake             4.0.2
WARNING: You are using pip version 19.2.3, however version 25.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.

```